### PR TITLE
New: Add the storage API (resumed)

### DIFF
--- a/storage/api.go
+++ b/storage/api.go
@@ -1,0 +1,79 @@
+package storage
+
+// Look here for various implementations:
+// 	https://github.com/puppetlabs/nebula-libs/tree/master/storage"
+//
+
+import (
+	"context"
+	"io"
+	"fmt"
+)
+
+type ErrorCode string
+
+const (
+	AuthError     ErrorCode = "AuthError"
+	NotFoundError ErrorCode = "NotFoundError"
+	TimeoutError  ErrorCode = "TimeoutError"
+	UnknownError  ErrorCode = "UnknownError"
+)
+
+type errorImpl struct {
+	message string
+	code    ErrorCode
+	cause   error
+}
+
+func (e *errorImpl) Error() string {
+	return e.message
+}
+
+func (e *errorImpl) Unwrap() error {
+	return e.cause
+}
+
+func Errorf(cause error, code ErrorCode, format string, a ...interface{}) error {
+	return &errorImpl{
+		code:     code,
+		message:  fmt.Sprintf(format, a...),
+		cause:    cause,
+	}
+}
+
+func IsAuthError(err error) bool {
+	e, ok := err.(*errorImpl)
+	return ok && e.code == AuthError
+}
+
+func IsNotFoundError(err error) bool {
+	e, ok := err.(*errorImpl)
+	return ok && e.code == NotFoundError
+}
+
+func IsTimeoutError(err error) bool {
+	e, ok := err.(*errorImpl)
+	return ok && e.code == TimeoutError
+}
+
+type Sink func(io.Writer) error
+type Source func(*Meta, io.Reader) error
+
+type Meta struct {
+	ContentType string
+}
+type PutOptions struct {
+	ContentType string
+}
+type GetOptions struct {
+	// TODO: Support range requests?
+}
+type DeleteOptions struct {
+	// TODO: Support conditional deletes?
+}
+
+type BlobStore interface {
+	Put(ctx context.Context, key string, sink Sink, opts PutOptions) error
+	Get(ctx context.Context, key string, source Source, opts GetOptions) error
+	Delete(ctx context.Context, key string, opts DeleteOptions) error
+}

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+var (
+	factoriesMu sync.RWMutex
+	factories   = make(map[string]BlobStoreFactory)
+)
+
+type BlobStoreFactory func(url.URL) (BlobStore, error)
+
+func NewBlobStore(u url.URL) (BlobStore, error) {
+	scheme := strings.ToLower(u.Scheme)
+	factoriesMu.RLock()
+	factory, ok := factories[scheme]
+	factoriesMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("stroage: unknown scheme %q (forgotten import?)", scheme)
+	}
+	return factory(u)
+}
+
+func RegisterFactory(scheme string, factory BlobStoreFactory) {
+	scheme = strings.ToLower(scheme)
+	factoriesMu.Lock()
+	defer factoriesMu.Unlock()
+	if nil == factory {
+		panic("storage: RegisterFactory passed a nil factory")
+	}
+	if _, dup := factories[scheme]; dup {
+		panic("storage: RegisterFactory called twice for factory " + scheme)
+	}
+	factories[scheme] = factory
+}
+
+func SupportedSchemes() []string {
+	factoriesMu.RLock()
+	defer factoriesMu.RUnlock()
+	var list []string
+	for scheme := range factories {
+		list = append(list, scheme)
+	}
+	return list
+}


### PR DESCRIPTION
Move away from using options for each method, per Noah's feedback.

I don't see a way to easily unmerge my changes, so here is one final change in response to Noah's feedback:

"""
Sometimes it's hard to feel out exactly where an Options struct makes the most sense, but I think here this might be overkill. Or, at least, it's making it hard to discern what things are actually required and what things are optional. I think it might be less confusing to have something like: ...
"""

This change brings back the `StorageMeta` (currently just for `ContentType`, but we could expand this in the future). It also removes the `*Options` structures. What do you think of this API?