### PR TITLE
Metrics library cleanup

### DIFF
--- a/instrumentation/examples/metrics_server/server.go
+++ b/instrumentation/examples/metrics_server/server.go
@@ -48,6 +48,12 @@ func (t testApp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		random := rand.Intn(10)
 		<-time.After(time.Millisecond * time.Duration(random))
 	})
+
+	// label override
+	h := gcsTimer.Start()
+	random := rand.Intn(10)
+	<-time.After(time.Millisecond * time.Duration(random))
+	gcsTimer.ObserveDuration(h, metrics.NewLabel("backend", "backblaze"), metrics.NewLabel("action", "post"))
 }
 
 func main() {

--- a/instrumentation/examples/metrics_server/server.go
+++ b/instrumentation/examples/metrics_server/server.go
@@ -99,13 +99,15 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/", mw.Wrap(testApp{m}))
 
+	log.Println("example server running at: http://localhost:2399/")
 	go http.ListenAndServe("localhost:2399", mux)
 
 	server := server.New(m, server.Options{
-		BindAddr: "localhost:2398",
-		Path:     "/metrics",
+		BindAddr: "localhost:3050",
+		Path:     "/",
 	})
 
+	log.Println("metrics server running at: http://localhost:3050/")
 	if err := server.Run(context.Background()); err != nil {
 		log.Fatal(err)
 	}

--- a/instrumentation/examples/metrics_server/server.go
+++ b/instrumentation/examples/metrics_server/server.go
@@ -26,19 +26,29 @@ type testApp struct {
 }
 
 func (t testApp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Calls MustCounter to get a metric registered as requestCounter (in this case it's name is request_count)
+	// and applys the label "method" with the request method.
 	c := t.m.MustCounter(requestCount, metrics.NewLabel("method", r.Method))
+	// Here we are using Add(1), but c.Inc() would also increment the count by one.
 	c.Add(1)
 
+	// Now we are getting a metric registered as storageBackendCall to track the duration of a function call
+	// that does some work with a storage backend. We are setting the labels backend=gcs and action=put to give
+	// the metric depth, allowing us to layer charts with more context about operations.
 	gcsTimer := t.m.MustTimer(storageBackendCall,
 		metrics.NewLabel("backend", "gcs"),
 		metrics.NewLabel("action", "put"),
 	)
 
+	// Using the timer we got from MustTimer, we are passing it into the OnTimer function that takes a callback.
+	// This wraps the func() to get a duration of how long it took to run by calling Start() on the timer, then calling
+	// func(), then calling ObserveDuration().
 	t.m.OnTimer(gcsTimer, func() {
 		random := rand.Intn(10)
 		<-time.After(time.Millisecond * time.Duration(random))
 	})
 
+	// This is during the same thing as the gcsTimer, but it's using the labels backend=s3 and action=get instead.
 	s3Timer := t.m.MustTimer(storageBackendCall,
 		metrics.NewLabel("backend", "s3"),
 		metrics.NewLabel("action", "get"),
@@ -49,7 +59,8 @@ func (t testApp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		<-time.After(time.Millisecond * time.Duration(random))
 	})
 
-	// label override
+	// This is demoing how we can use the gcsTimer metric without OnTimer and also how we can change the labels
+	// once we want to ObserveDuration()
 	h := gcsTimer.Start()
 	random := rand.Intn(10)
 	<-time.After(time.Millisecond * time.Duration(random))
@@ -57,6 +68,9 @@ func (t testApp) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// We start bootstrapping our metrics collection by creating a new metrics.Metric object
+	// that represents a namespace. This is essencially bucketizing this specific system in the
+	// metrics storage backend. The namespace must only include characters a-z and _.
 	m, err := metrics.NewNamespace(namespace, metrics.Options{
 		DelegateType:  delegates.PrometheusDelegate,
 		ErrorBehavior: metrics.ErrorBehaviorLog,
@@ -65,6 +79,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Now we are registering a Counter metric as requestCount. All metrics that you want to use need to be
+	// registered with the metrics.Metric object.
+	//
+	// Here we are calling RegisterCounter, which could return an error. This error must be handled by the caller.
 	copts := collectors.CounterOptions{
 		Description: "a count of requests executed",
 		Labels:      []string{"method"},
@@ -73,6 +91,9 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Now we are registering another Counter, but using MustRegisterCounter. This will catch any error returned
+	// and pass it to the internal metrics.handleError method, which can be configured to handle the error automatically.
+	// The default error handling behavior is to log the error and return a noop metric, which will do nothing.
 	m.MustRegisterCounter(taskCount, collectors.CounterOptions{
 		Description: "a count of tasks executed",
 		Labels:      []string{"status"},
@@ -94,6 +115,9 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// This is an example of pre-configuring metrics with label values. This is useful if your label values
+	// are constant (which they should be due to heavy resource usage with high cardinality data). You can create
+	// a map if these labeled metrics and grab the one you want to observe with a key from a list of consts.
 	failedTasks := m.MustCounter(taskCount, metrics.NewLabel("status", "failed"))
 	failedTasks.Add(5)
 
@@ -101,6 +125,9 @@ func main() {
 	succeededTasks.Add(1)
 	succeededTasks.Inc()
 
+	// This one creates a labeled metric that is a HTTP middleware handler that will track the duration
+	// of all HTTP handlers wrapped by it. If the URL contains user IDs or something, don't add a label
+	// that has the path in it. This will cause most metric backends to explode.
 	mw := m.MustDurationMiddleware(httpRequestDuration, metrics.NewLabel("handler", "test_handler"))
 	mux := http.NewServeMux()
 	mux.Handle("/", mw.Wrap(testApp{m}))
@@ -108,6 +135,8 @@ func main() {
 	log.Println("example server running at: http://localhost:2399/")
 	go http.ListenAndServe("localhost:2399", mux)
 
+	// Now that we have registered a bunch of metrics and configured them, we now create a metrics.Server
+	// (which is just a HTTP server) and tell it to serve the metrics on http://locahost:3050/
 	server := server.New(m, server.Options{
 		BindAddr: "localhost:3050",
 		Path:     "/",

--- a/instrumentation/metrics/collectors/counter.go
+++ b/instrumentation/metrics/collectors/counter.go
@@ -1,12 +1,21 @@
 package collectors
 
+// CounterOptions is used to configure a counter metric with labels
+// that must be used when incrementing.
 type CounterOptions struct {
 	Description string
 	Labels      []string
 }
 
+// Counter is a metric that always counts up. You can either Add() a number
+// of 0 or more, or use Inc() to increment the count by one.
 type Counter interface {
+	// WithLabels takes a slice of Labels and returns a new Counter with
+	// those label attached.
 	WithLabels([]Label) (Counter, error)
+	// Inc increments the count for the configured metric in the backend.
 	Inc()
+	// Add takes a float64 that must be a positive number >= 0. If the float64
+	// is < 0 then Add will panic.
 	Add(float64)
 }

--- a/instrumentation/metrics/collectors/labels.go
+++ b/instrumentation/metrics/collectors/labels.go
@@ -1,5 +1,6 @@
 package collectors
 
+// Label is a type that represents a named label and its value.
 type Label struct {
 	Name  string
 	Value string

--- a/instrumentation/metrics/collectors/timer.go
+++ b/instrumentation/metrics/collectors/timer.go
@@ -15,6 +15,11 @@ type TimerOptions struct {
 type Timer interface {
 	// WithLabels returns a new Timer with labels attached.
 	WithLabels(...Label) Timer
+	// Start starts the timer clock and returns a TimerHandle that represents a specific
+	// clock that's ticking.
 	Start() *TimerHandle
+	// ObserveDuration takes a TimerHandle and stops the clock, recording the duration
+	// that elapsed to the metrics backend. Optionally takes labels to apply. This is
+	// useful if you want to record the duration on a metric labeled as a failure.
 	ObserveDuration(*TimerHandle, ...Label)
 }

--- a/instrumentation/metrics/collectors/timer.go
+++ b/instrumentation/metrics/collectors/timer.go
@@ -1,15 +1,20 @@
 package collectors
 
+// TimerHandle is a type used to map running timers for defered observations.
 type TimerHandle struct{}
 
+// TimerOptions is used to configure a timer with labels and histogram boundaries.
 type TimerOptions struct {
 	Description         string
 	Labels              []string
 	HistogramBoundaries []float64
 }
 
+// Timer is a named metric with labels. It allows concurrent use by returning a handle
+// when the timer is started. This handle is used to lookup a running timer to record the duration.
 type Timer interface {
-	WithLabels([]Label) (Timer, error)
+	// WithLabels returns a new Timer with labels attached.
+	WithLabels(...Label) Timer
 	Start() *TimerHandle
-	ObserveDuration(*TimerHandle)
+	ObserveDuration(*TimerHandle, ...Label)
 }

--- a/instrumentation/metrics/internal/noop/timer.go
+++ b/instrumentation/metrics/internal/noop/timer.go
@@ -4,6 +4,6 @@ import "github.com/puppetlabs/horsehead/v2/instrumentation/metrics/collectors"
 
 type Timer struct{}
 
-func (n Timer) WithLabels([]collectors.Label) (collectors.Timer, error) { return n, nil }
-func (n Timer) Start() *collectors.TimerHandle                          { return &collectors.TimerHandle{} }
-func (n Timer) ObserveDuration(*collectors.TimerHandle)                 {}
+func (n Timer) WithLabels(...collectors.Label) collectors.Timer              { return n }
+func (n Timer) Start() *collectors.TimerHandle                               { return &collectors.TimerHandle{} }
+func (n Timer) ObserveDuration(*collectors.TimerHandle, ...collectors.Label) {}

--- a/instrumentation/metrics/internal/prometheus/timer.go
+++ b/instrumentation/metrics/internal/prometheus/timer.go
@@ -44,7 +44,9 @@ func (t *Timer) ObserveDuration(h *collectors.TimerHandle, labels ...collectors.
 	t.RLock()
 	defer t.RUnlock()
 
-	t.labels = labels
+	if len(labels) > 0 {
+		t.labels = labels
+	}
 
 	if promt, ok := t.timers[h]; ok {
 		promt.ObserveDuration()

--- a/instrumentation/metrics/metrics.go
+++ b/instrumentation/metrics/metrics.go
@@ -62,14 +62,15 @@ func (m *Metrics) RegisterTimer(name string, opts collectors.TimerOptions) error
 	return nil
 }
 
-// MustRegisterTimer calls RegisterTimer and logs an error if one occurs
+// MustRegisterTimer is like RegisterTimer but if an error is returned, it will pass
+// it to the configured error handler.
 func (m *Metrics) MustRegisterTimer(name string, opts collectors.TimerOptions) {
 	if err := m.RegisterTimer(name, opts); err != nil {
 		m.handleError(err)
 	}
 }
 
-// Timer returns a Timer metric at name
+// Timer returns a Timer metric registered as name.
 func (m *Metrics) Timer(name string) (collectors.Timer, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -103,6 +104,8 @@ func (m *Metrics) OnTimer(t collectors.Timer, fn func()) {
 	t.ObserveDuration(h)
 }
 
+// RegisterCounter registers a counter metric in the metrics backend as name. A counter
+// metric cannot be used unless it was first registered.
 func (m *Metrics) RegisterCounter(name string, opts collectors.CounterOptions) error {
 	m.Lock()
 	defer m.Unlock()
@@ -119,6 +122,8 @@ func (m *Metrics) RegisterCounter(name string, opts collectors.CounterOptions) e
 	return nil
 }
 
+// MustRegisterCounter is like RegisterCounter but if an error is returned, it will pass
+// it to the configured error handler.
 func (m *Metrics) MustRegisterCounter(name string, opts collectors.CounterOptions) {
 	if err := m.RegisterCounter(name, opts); err != nil {
 		m.handleError(err)
@@ -137,6 +142,9 @@ func (m *Metrics) Counter(name string) (collectors.Counter, error) {
 	return m.counters[name], nil
 }
 
+// MustCounter is like Counter but if an error is returned, it will pass it to
+// the configured error handler and return a noop.Counter{} allowing programs to
+// continue to function instead of crashing.
 func (m *Metrics) MustCounter(name string, labels ...collectors.Label) collectors.Counter {
 	c, err := m.Counter(name)
 	if err != nil {
@@ -155,6 +163,7 @@ func (m *Metrics) MustCounter(name string, labels ...collectors.Label) collector
 	return c
 }
 
+// RegisterDurationMiddleware registers a HTTP duration middleware metric in the metrics backend as name.
 func (m *Metrics) RegisterDurationMiddleware(name string, opts collectors.DurationMiddlewareOptions) error {
 	m.Lock()
 	defer m.Unlock()
@@ -171,12 +180,15 @@ func (m *Metrics) RegisterDurationMiddleware(name string, opts collectors.Durati
 	return nil
 }
 
+// MustRegisterDurationMiddleware is like RegisterDurationMiddleware but if an error is returned, it will pass
+// it to the configured error handler.
 func (m *Metrics) MustRegisterDurationMiddleware(name string, opts collectors.DurationMiddlewareOptions) {
 	if err := m.RegisterDurationMiddleware(name, opts); err != nil {
 		m.handleError(err)
 	}
 }
 
+// DurationMiddleware returns a new DurationMiddleware register as name.
 func (m *Metrics) DurationMiddleware(name string) (collectors.DurationMiddleware, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -188,6 +200,8 @@ func (m *Metrics) DurationMiddleware(name string) (collectors.DurationMiddleware
 	return m.durationMiddleware[name], nil
 }
 
+// MustDurationMiddleware is like DurationMiddleware but if an error is returned, it will pass
+// it to the configured error handler.
 func (m *Metrics) MustDurationMiddleware(name string, labels ...collectors.Label) collectors.DurationMiddleware {
 	d, err := m.DurationMiddleware(name)
 	if err != nil {
@@ -206,7 +220,7 @@ func (m *Metrics) MustDurationMiddleware(name string, labels ...collectors.Label
 	return d
 }
 
-// Handler returns the http handler from the delegate if there is one
+// Handler returns the http handler from the delegate if there is one.
 func (m *Metrics) Handler() http.Handler {
 	return m.delegate.NewHandler()
 }

--- a/instrumentation/metrics/metrics.go
+++ b/instrumentation/metrics/metrics.go
@@ -91,12 +91,7 @@ func (m *Metrics) MustTimer(name string, labels ...collectors.Label) collectors.
 		return noop.Timer{}
 	}
 
-	t, err = t.WithLabels(labels)
-	if err != nil {
-		m.handleError(err)
-
-		return noop.Timer{}
-	}
+	t = t.WithLabels(labels...)
 
 	return t
 }


### PR DESCRIPTION
We often need the ability to update label values on a timer that's in
flight and originally we would create a delegate, that was a prometheus
Observer when the timer is started. This isn't needed as we can just
create the observer on the fly when we want to stop the timer and
observe the duration, allowing us to set the labels that can be passed
in.