### PR TITLE
Update: Add noop metrics delegate for testing

### DIFF
--- a/instrumentation/metrics/delegates/delegates.go
+++ b/instrumentation/metrics/delegates/delegates.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/puppetlabs/horsehead/v2/instrumentation/metrics/collectors"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/metrics/internal/noop"
 	"github.com/puppetlabs/horsehead/v2/instrumentation/metrics/internal/prometheus"
 )
 
@@ -22,6 +23,7 @@ type DelegateType string
 const (
 	// PrometheusDelegate is a const that represents the prometheus backend
 	PrometheusDelegate DelegateType = "prometheus"
+	NoopDelegate       DelegateType = "noop"
 )
 
 // New looks up t and returns a new Delegate matching that type
@@ -29,6 +31,8 @@ func New(namespace string, t DelegateType) (Delegate, error) {
 	switch t {
 	case PrometheusDelegate:
 		return prometheus.New(namespace), nil
+	case NoopDelegate:
+		return noop.New(), nil
 	}
 
 	return nil, errors.New("no delegate found")

--- a/instrumentation/metrics/internal/noop/noop.go
+++ b/instrumentation/metrics/internal/noop/noop.go
@@ -1,0 +1,29 @@
+package noop
+
+import (
+	"net/http"
+
+	"github.com/puppetlabs/horsehead/v2/instrumentation/metrics/collectors"
+)
+
+type Noop struct{}
+
+func (n *Noop) NewCounter(name string, opts collectors.CounterOptions) (collectors.Counter, error) {
+	return &Counter{}, nil
+}
+
+func (n *Noop) NewTimer(name string, opts collectors.TimerOptions) (collectors.Timer, error) {
+	return &Timer{}, nil
+}
+
+func (n *Noop) NewDurationMiddleware(name string, opts collectors.DurationMiddlewareOptions) (collectors.DurationMiddleware, error) {
+	return &DurationMiddleware{}, nil
+}
+
+func (n *Noop) NewHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func New() *Noop {
+	return &Noop{}
+}


### PR DESCRIPTION
This commit adds a noop delegate to instrumentation/metrics that will just do nothing. It will not
register metrics or record them. This is used for testing packages that use Horsehead for
instrumenetation. Prometheus registers everything in a global registry at the moment, so errors can
arise in the lifecycle of tests related to metrics already having been registered. This can create
issues when inspecting the call stack and output logs of tests.