### PR TITLE
Add support for deduplicating activity data

### DIFF
--- a/instrumentation/activities/activity.go
+++ b/instrumentation/activities/activity.go
@@ -1,5 +1,6 @@
 package activities
 
+import "strings"
 import "time"
 import "github.com/puppetlabs/horsehead/v2/instrumentation/activities/activity"
 
@@ -11,4 +12,8 @@ func NewActivity(userID, name string) activity.Activity {
 		Metadata:  make(activity.ActivityMetadata),
 		OccuredAt: time.Now(),
 	}
+}
+
+func Identifier(comps ...string) string {
+	return strings.Join(comps, "-")
 }

--- a/instrumentation/activities/activity/activity.go
+++ b/instrumentation/activities/activity/activity.go
@@ -5,8 +5,15 @@ import "time"
 type ActivityMetadata map[string]string
 
 type Activity struct {
+	// ID is a unique identifier for this activity. Activity data consumers will
+	// use this identifier (when provided) to deduplicated activity data.
+	ID string
+
+	// Name is the name of the activity to report. e.g. "workflow-run"
+	Name string
+
+	// UserID is the identifier of the user that this activity belongs to.
 	UserID    string
-	Name      string
 	Metadata  ActivityMetadata
 	OccuredAt time.Time
 }

--- a/instrumentation/activities/delegates/intercom.go
+++ b/instrumentation/activities/delegates/intercom.go
@@ -13,7 +13,6 @@ type Intercom struct {
 
 func (d *Intercom) Report(act activity.Activity) error {
 	return d.client.Events.Save(&intercom.Event{
-		ID:        act.ID,
 		UserID:    act.UserID,
 		EventName: act.Name,
 		CreatedAt: act.OccuredAt.Unix(),

--- a/instrumentation/activities/delegates/intercom.go
+++ b/instrumentation/activities/delegates/intercom.go
@@ -13,6 +13,7 @@ type Intercom struct {
 
 func (d *Intercom) Report(act activity.Activity) error {
 	return d.client.Events.Save(&intercom.Event{
+		ID:        act.ID,
 		UserID:    act.UserID,
 		EventName: act.Name,
 		CreatedAt: act.OccuredAt.Unix(),

--- a/instrumentation/activities/delegates/segment.go
+++ b/instrumentation/activities/delegates/segment.go
@@ -14,6 +14,7 @@ type Segment struct {
 
 func (d *Segment) Report(act activity.Activity) error {
 	track := analytics.Track{
+		MessageId:  act.ID,
 		UserId:     act.UserID,
 		Event:      act.Name,
 		Timestamp:  act.OccuredAt,


### PR DESCRIPTION
This PR introduces minor changes to the activity data model to (optionally) let upstream activity data consumers deduplicate activity data when relevant.