### PR TITLE
Adding passthrough and SNS delegates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go/storage v1.9.0
 	github.com/DATA-DOG/go-sqlmock v1.3.3
+	github.com/aws/aws-sdk-go v1.35.14
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261 // indirect
@@ -18,7 +19,6 @@ require (
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v0.9.0
 	github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 // indirect
 	github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d // indirect
@@ -32,5 +32,4 @@ require (
 	google.golang.org/api v0.26.0
 	gopkg.in/intercom/intercom-go.v2 v2.0.0-20200217143803-6ffc0627261a
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0
-	gopkg.in/yaml.v2 v2.2.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/aws/aws-sdk-go v1.35.14 h1:nucVVXXjAr9UkmYCBWxQWRuYa5KOlaXjuJGg2ulW0K0=
+github.com/aws/aws-sdk-go v1.35.14/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -130,6 +132,9 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec h1:CGkYB1Q7DSsH/ku+to+foV4agt2F2miquaLUgF6L178=
 github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -155,6 +160,8 @@ github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 h1:zNBQb37RGLmJybyMcs
 github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.0 h1:tXuTFVHC03mW0D+Ua1Q2d1EAVqLTuggX50V0VLICCzY=
@@ -453,6 +460,8 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/instrumentation/alerts/alerts.go
+++ b/instrumentation/alerts/alerts.go
@@ -1,8 +1,11 @@
 package alerts
 
 import (
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/internal/noop"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/internal/passthrough"
 	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/internal/sentry"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/internal/sns"
 	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
 	"github.com/puppetlabs/horsehead/v2/instrumentation/errors"
 )
@@ -16,6 +19,34 @@ type DelegateFunc func(opts Options) Delegate
 
 func NoDelegate(opts Options) Delegate {
 	return &noop.NoOp{}
+}
+
+func DelegateToPassthrough() (DelegateFunc, errors.Error) {
+	b, err := passthrough.NewBuilder()
+	if err != nil {
+		return nil, err
+	}
+
+	fn := func(opts Options) Delegate {
+		return b.WithEnvironment(opts.Environment).
+			WithRelease(opts.Version).
+			Build()
+	}
+	return fn, nil
+}
+
+func DelegateToSNS(arn string, sopts session.Options) (DelegateFunc, errors.Error) {
+	b, err := sns.NewBuilder(arn, sopts)
+	if err != nil {
+		return nil, err
+	}
+
+	fn := func(opts Options) Delegate {
+		return b.WithEnvironment(opts.Environment).
+			WithRelease(opts.Version).
+			Build()
+	}
+	return fn, nil
 }
 
 func DelegateToSentry(dsn string) (DelegateFunc, errors.Error) {

--- a/instrumentation/alerts/internal/passthrough/capturer.go
+++ b/instrumentation/alerts/internal/passthrough/capturer.go
@@ -1,0 +1,105 @@
+package passthrough
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+)
+
+type Capturer struct {
+	newTrace    bool
+	appPackages []string
+	user        *trackers.User
+	tags        []trackers.Tag
+}
+
+func (c Capturer) WithNewTrace() trackers.Capturer {
+	return &Capturer{
+		newTrace:    true,
+		appPackages: append([]string{}, c.appPackages...),
+		user:        c.user,
+		tags:        append([]trackers.Tag{}, c.tags...),
+	}
+}
+
+func (c Capturer) WithAppPackages(packages []string) trackers.Capturer {
+	return &Capturer{
+		newTrace:    c.newTrace,
+		appPackages: append(append([]string{}, c.appPackages...), packages...),
+		user:        c.user,
+		tags:        append([]trackers.Tag{}, c.tags...),
+	}
+}
+
+func (c Capturer) withUser(u trackers.User) *Capturer {
+	return &Capturer{
+		newTrace:    c.newTrace,
+		appPackages: append([]string{}, c.appPackages...),
+		user:        &u,
+		tags:        append([]trackers.Tag{}, c.tags...),
+	}
+}
+
+func (c Capturer) WithUser(u trackers.User) trackers.Capturer {
+	return c.withUser(u)
+}
+
+func (c Capturer) withTags(tags []trackers.Tag) *Capturer {
+	return &Capturer{
+		newTrace:    c.newTrace,
+		appPackages: append([]string{}, c.appPackages...),
+		user:        c.user,
+		tags:        append(append([]trackers.Tag{}, c.tags...), tags...),
+	}
+}
+
+func (c Capturer) WithTags(tags ...trackers.Tag) trackers.Capturer {
+	return c.withTags(tags)
+}
+
+func (c *Capturer) Try(ctx context.Context, fn func(ctx context.Context)) (rv interface{}) {
+	ctx = trackers.NewContextWithCapturer(ctx, c)
+
+	defer func() {
+		var reporter trackers.Reporter
+
+		rv = recover()
+		switch rvt := rv.(type) {
+		case nil:
+			return
+		case error:
+			reporter = c.Capture(rvt)
+		default:
+			reporter = c.CaptureMessage(fmt.Sprint(rvt))
+		}
+
+		reporter.Report(ctx)
+	}()
+
+	fn(ctx)
+	return
+}
+
+func (c *Capturer) captureWithStack(err error, skip int) trackers.Reporter {
+	return &Reporter{
+		c:     c,
+		err:   err,
+		trace: c.newTrace,
+		fs:    trackers.NewTrace(skip + 1),
+	}
+}
+
+func (c *Capturer) Capture(err error) trackers.Reporter {
+	return c.captureWithStack(err, 1)
+}
+
+func (c Capturer) CaptureMessage(message string) trackers.Reporter {
+	return c.captureWithStack(fmt.Errorf(message), 1)
+}
+
+func (c *Capturer) Middleware() trackers.Middleware {
+	return &Middleware{
+		c: c,
+	}
+}

--- a/instrumentation/alerts/internal/passthrough/middleware.go
+++ b/instrumentation/alerts/internal/passthrough/middleware.go
@@ -1,0 +1,28 @@
+package passthrough
+
+import (
+	"net/http"
+
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/internal/httputil"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+)
+
+type Middleware struct {
+	c *Capturer
+}
+
+func (m Middleware) WithTags(tags ...trackers.Tag) trackers.Middleware {
+	return &Middleware{
+		c: m.c.withTags(tags),
+	}
+}
+
+func (m Middleware) WithUser(u trackers.User) trackers.Middleware {
+	return &Middleware{
+		c: m.c.withUser(u),
+	}
+}
+
+func (m Middleware) Wrap(target http.Handler) http.Handler {
+	return httputil.Wrap(target, httputil.WrapStatic(m.c))
+}

--- a/instrumentation/alerts/internal/passthrough/passthrough.go
+++ b/instrumentation/alerts/internal/passthrough/passthrough.go
@@ -1,0 +1,33 @@
+package passthrough
+
+import (
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/errors"
+)
+
+type Passthrough struct {
+}
+
+func (p Passthrough) NewCapturer() trackers.Capturer {
+	return &Capturer{}
+}
+
+type Builder struct {
+}
+
+func (b *Builder) WithEnvironment(environment string) *Builder {
+	return b
+}
+
+func (b *Builder) WithRelease(release string) *Builder {
+	return b
+}
+
+func (b *Builder) Build() *Passthrough {
+	return &Passthrough{}
+}
+
+func NewBuilder() (*Builder, errors.Error) {
+	b := &Builder{}
+	return b, nil
+}

--- a/instrumentation/alerts/internal/passthrough/reporter.go
+++ b/instrumentation/alerts/internal/passthrough/reporter.go
@@ -1,0 +1,94 @@
+package passthrough
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+)
+
+type Reporter struct {
+	c     *Capturer
+	err   error
+	trace bool
+	fs    *trackers.Trace
+	tags  []trackers.Tag
+}
+
+func (r Reporter) WithNewTrace() trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: true,
+		fs:    r.fs,
+		tags:  append([]trackers.Tag{}, r.tags...),
+	}
+}
+
+func (r Reporter) WithTrace(t *trackers.Trace) trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: true,
+		fs:    t,
+		tags:  append([]trackers.Tag{}, r.tags...),
+	}
+}
+
+func (r Reporter) WithTags(tags ...trackers.Tag) trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: r.trace,
+		fs:    r.fs,
+		tags:  append(append([]trackers.Tag{}, r.tags...), tags...),
+	}
+}
+
+func (r Reporter) AsWarning() trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: r.trace,
+		fs:    r.fs,
+		tags:  append([]trackers.Tag{}, r.tags...),
+	}
+}
+
+func (r Reporter) Report(ctx context.Context) <-chan error {
+	if r.err == nil {
+		ch := make(chan error, 1)
+		ch <- nil
+		return ch
+	}
+
+	// TODO Improve message format
+	message := fmt.Sprintf("Error: %v\nUser: %v\nTags: %v\nPackages: %v\n",
+		r.err.Error(), r.c.user, r.c.tags, r.c.appPackages)
+
+	if r.trace {
+		gfs := r.fs.Frames()
+		for {
+			gf, more := gfs.Next()
+			if !more {
+				break
+			}
+
+			if gf.Func == nil {
+				continue
+			}
+
+			message += fmt.Sprintf("%v %v %v %v\n", gf.PC, gf.Function, gf.File, gf.Line)
+		}
+	}
+
+	fmt.Println(message)
+
+	ch := make(chan error, 1)
+	ch <- nil
+	return ch
+}
+
+func (r Reporter) ReportSync(ctx context.Context) error {
+	return <-r.Report(ctx)
+}

--- a/instrumentation/alerts/internal/sns/capturer.go
+++ b/instrumentation/alerts/internal/sns/capturer.go
@@ -1,0 +1,116 @@
+package sns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+)
+
+type Capturer struct {
+	arn         string
+	sopts       session.Options
+	newTrace    bool
+	appPackages []string
+	user        *trackers.User
+	tags        []trackers.Tag
+}
+
+func (c Capturer) WithNewTrace() trackers.Capturer {
+	return &Capturer{
+		arn:         c.arn,
+		sopts:       c.sopts,
+		newTrace:    true,
+		appPackages: append([]string{}, c.appPackages...),
+		user:        c.user,
+		tags:        append([]trackers.Tag{}, c.tags...),
+	}
+}
+
+func (c Capturer) WithAppPackages(packages []string) trackers.Capturer {
+	return &Capturer{
+		arn:         c.arn,
+		sopts:       c.sopts,
+		newTrace:    c.newTrace,
+		appPackages: append(append([]string{}, c.appPackages...), packages...),
+		user:        c.user,
+		tags:        append([]trackers.Tag{}, c.tags...),
+	}
+}
+
+func (c Capturer) withUser(u trackers.User) *Capturer {
+	return &Capturer{
+		arn:         c.arn,
+		sopts:       c.sopts,
+		newTrace:    c.newTrace,
+		appPackages: append([]string{}, c.appPackages...),
+		user:        &u,
+		tags:        append([]trackers.Tag{}, c.tags...),
+	}
+}
+
+func (c Capturer) WithUser(u trackers.User) trackers.Capturer {
+	return c.withUser(u)
+}
+
+func (c Capturer) withTags(tags []trackers.Tag) *Capturer {
+	return &Capturer{
+		arn:         c.arn,
+		sopts:       c.sopts,
+		newTrace:    c.newTrace,
+		appPackages: append([]string{}, c.appPackages...),
+		user:        c.user,
+		tags:        append(append([]trackers.Tag{}, c.tags...), tags...),
+	}
+}
+
+func (c Capturer) WithTags(tags ...trackers.Tag) trackers.Capturer {
+	return c.withTags(tags)
+}
+
+func (c *Capturer) Try(ctx context.Context, fn func(ctx context.Context)) (rv interface{}) {
+	ctx = trackers.NewContextWithCapturer(ctx, c)
+
+	defer func() {
+		var reporter trackers.Reporter
+
+		rv = recover()
+		switch rvt := rv.(type) {
+		case nil:
+			return
+		case error:
+			reporter = c.Capture(rvt)
+		default:
+			reporter = c.CaptureMessage(fmt.Sprint(rvt))
+		}
+
+		reporter.Report(ctx)
+	}()
+
+	fn(ctx)
+	return
+}
+
+func (c *Capturer) captureWithStack(err error, skip int) trackers.Reporter {
+	return &Reporter{
+		c:     c,
+		err:   err,
+		trace: c.newTrace,
+		fs:    trackers.NewTrace(skip + 1),
+	}
+}
+
+func (c *Capturer) Capture(err error) trackers.Reporter {
+	return c.captureWithStack(err, 1)
+}
+
+func (c Capturer) CaptureMessage(message string) trackers.Reporter {
+	return c.captureWithStack(fmt.Errorf(message), 1)
+}
+
+func (c *Capturer) Middleware() trackers.Middleware {
+	return &Middleware{
+		c: c,
+	}
+}

--- a/instrumentation/alerts/internal/sns/middleware.go
+++ b/instrumentation/alerts/internal/sns/middleware.go
@@ -1,0 +1,28 @@
+package sns
+
+import (
+	"net/http"
+
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/internal/httputil"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+)
+
+type Middleware struct {
+	c *Capturer
+}
+
+func (m Middleware) WithTags(tags ...trackers.Tag) trackers.Middleware {
+	return &Middleware{
+		c: m.c.withTags(tags),
+	}
+}
+
+func (m Middleware) WithUser(u trackers.User) trackers.Middleware {
+	return &Middleware{
+		c: m.c.withUser(u),
+	}
+}
+
+func (m Middleware) Wrap(target http.Handler) http.Handler {
+	return httputil.Wrap(target, httputil.WrapStatic(m.c))
+}

--- a/instrumentation/alerts/internal/sns/reporter.go
+++ b/instrumentation/alerts/internal/sns/reporter.go
@@ -1,0 +1,103 @@
+package sns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+)
+
+type Reporter struct {
+	c     *Capturer
+	err   error
+	trace bool
+	fs    *trackers.Trace
+	tags  []trackers.Tag
+}
+
+func (r Reporter) WithNewTrace() trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: true,
+		fs:    r.fs,
+		tags:  append([]trackers.Tag{}, r.tags...),
+	}
+}
+
+func (r Reporter) WithTrace(t *trackers.Trace) trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: true,
+		fs:    t,
+		tags:  append([]trackers.Tag{}, r.tags...),
+	}
+}
+
+func (r Reporter) WithTags(tags ...trackers.Tag) trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: r.trace,
+		fs:    r.fs,
+		tags:  append(append([]trackers.Tag{}, r.tags...), tags...),
+	}
+}
+
+func (r Reporter) AsWarning() trackers.Reporter {
+	return &Reporter{
+		c:     r.c,
+		err:   r.err,
+		trace: r.trace,
+		fs:    r.fs,
+		tags:  append([]trackers.Tag{}, r.tags...),
+	}
+}
+
+func (r Reporter) Report(ctx context.Context) <-chan error {
+	if r.err == nil {
+		ch := make(chan error, 1)
+		ch <- nil
+		return ch
+	}
+
+	// TODO Change this to JSON structure
+	message := fmt.Sprintf("Error: %v\nUser: %v\nTags: %v\nPackages: %v\n",
+		r.err.Error(), r.c.user, r.c.tags, r.c.appPackages)
+
+	if r.trace {
+		gfs := r.fs.Frames()
+		for {
+			gf, more := gfs.Next()
+			if !more {
+				break
+			}
+
+			if gf.Func == nil {
+				continue
+			}
+
+			message += fmt.Sprintf("%v %v %v %v\n", gf.PC, gf.Function, gf.File, gf.Line)
+		}
+	}
+
+	sess := session.Must(session.NewSessionWithOptions(r.c.sopts))
+
+	svc := sns.New(sess)
+
+	svc.Publish(&sns.PublishInput{
+		Message:  &message,
+		TopicArn: &r.c.arn,
+	})
+
+	ch := make(chan error, 1)
+	ch <- nil
+	return ch
+}
+
+func (r Reporter) ReportSync(ctx context.Context) error {
+	return <-r.Report(ctx)
+}

--- a/instrumentation/alerts/internal/sns/sns.go
+++ b/instrumentation/alerts/internal/sns/sns.go
@@ -1,0 +1,47 @@
+package sns
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/alerts/trackers"
+	"github.com/puppetlabs/horsehead/v2/instrumentation/errors"
+)
+
+type SNS struct {
+	arn   string
+	sopts session.Options
+}
+
+func (s SNS) NewCapturer() trackers.Capturer {
+	return &Capturer{
+		arn:   s.arn,
+		sopts: s.sopts,
+	}
+}
+
+type Builder struct {
+	arn   string
+	sopts session.Options
+}
+
+func (b *Builder) WithEnvironment(environment string) *Builder {
+	return b
+}
+
+func (b *Builder) WithRelease(release string) *Builder {
+	return b
+}
+
+func (b *Builder) Build() *SNS {
+	return &SNS{
+		arn:   b.arn,
+		sopts: b.sopts,
+	}
+}
+
+func NewBuilder(arn string, sopts session.Options) (*Builder, errors.Error) {
+	b := &Builder{
+		arn:   arn,
+		sopts: sopts,
+	}
+	return b, nil
+}


### PR DESCRIPTION
@impl 

This is a rough draft of code I was using to test with, so it's fairly raw and unfinished right now. I was mostly using this to observe issues locally without the need for Sentry. The "passthrough" delegate is just printing right now, but I wanted the SNS changes as well, given that it's a very easy option that allows alerting (i.e. SMS) and queueing (i.e. SQS).